### PR TITLE
Removed conflicting async transform plugin

### DIFF
--- a/config/babel/browser/dev/index.js
+++ b/config/babel/browser/dev/index.js
@@ -9,7 +9,6 @@ module.exports = {
     'babel-plugin-syntax-jsx',
     'babel-plugin-syntax-object-rest-spread',
     'babel-plugin-syntax-trailing-function-commas',
-    'babel-plugin-transform-async-to-generator',
     ['babel-plugin-transform-async-to-module-method', {
       'module': 'bluebird',
       'method': 'coroutine',

--- a/config/babel/browser/prod/index.js
+++ b/config/babel/browser/prod/index.js
@@ -9,7 +9,6 @@ module.exports = {
     'babel-plugin-syntax-jsx',
     'babel-plugin-syntax-object-rest-spread',
     'babel-plugin-syntax-trailing-function-commas',
-    'babel-plugin-transform-async-to-generator',
     ['babel-plugin-transform-async-to-module-method', {
       'module': 'bluebird',
       'method': 'coroutine',

--- a/config/babel/node/dev/index.js
+++ b/config/babel/node/dev/index.js
@@ -9,7 +9,6 @@ module.exports = {
     'babel-plugin-syntax-jsx',
     'babel-plugin-syntax-object-rest-spread',
     'babel-plugin-syntax-trailing-function-commas',
-    'babel-plugin-transform-async-to-generator',
     ['babel-plugin-transform-async-to-module-method', {
       'module': 'bluebird',
       'method': 'coroutine',

--- a/config/babel/node/prod/index.js
+++ b/config/babel/node/prod/index.js
@@ -46,7 +46,6 @@ module.exports = {
     'babel-plugin-transform-es2015-typeof-symbol',
     'babel-plugin-transform-es2015-unicode-regex',
     ['babel-plugin-transform-es2015-modules-commonjs', { loose: true }],
-    'babel-plugin-transform-async-to-generator',
     ['babel-plugin-transform-async-to-module-method', {
       'module': 'bluebird',
       'method': 'coroutine',

--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -16,6 +16,14 @@ describe('sanity', () => {
     should(multiplyByFortyFive()).be.exactly(TEN * THIRTYFIVE);
     should(ComplexClass.multiplyByFortyFive(TEN)).be.exactly(TEN * THIRTYFIVE);
   });
+  it('should transform async functions properly', () => {
+    async function asyncFunc() {
+      const result = await Promise.resolve('foobar');
+      return result;
+    }
+
+    return asyncFunc().then((result) => should(result).be.exactly('foobar'));
+  });
 });
 
 describe('index', () =>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-plugin-syntax-jsx": "^6.3.13",
     "babel-plugin-syntax-object-rest-spread": "^6.3.13",
     "babel-plugin-syntax-trailing-function-commas": "^6.3.13",
-    "babel-plugin-transform-async-to-generator": "^6.3.13",
     "babel-plugin-transform-async-to-module-method": "^6.3.13",
     "babel-plugin-transform-class-constructor-call": "^6.3.13",
     "babel-plugin-transform-class-properties": "^6.3.13",


### PR DESCRIPTION
`babel-plugin-transform-async-to-generator` was conflicting with
`babel-plugin-transform-async-to-module-method`, effectively denying the latter to perform any transformation.

This pr removes `babel-plugin-transform-async-to-generator` altogether, the resulting code uses   `bluebird.coroutine()`
